### PR TITLE
only test with node 8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,4 @@ env:
   CXX=g++-4.8
 language: node_js
 node_js:
-  - "4"
-  - "6"
-  - "7"
+  - "8"


### PR DESCRIPTION
Followup to #591.

Node.js v4 is reaching End of Life this month. https://github.com/nodejs/Release/tree/643af71ee8365efbdccaa134690425ea05931279#release-schedule