### PR TITLE
generate 256px resized icons

### DIFF
--- a/script/pack.js
+++ b/script/pack.js
@@ -22,6 +22,7 @@ fs.readdirSync(path.join(__dirname, '../apps'))
       icon32: `${slug}-icon-32.png`,
       icon64: `${slug}-icon-64.png`,
       icon128: `${slug}-icon-128.png`,
+      icon256: `${slug}-icon-256.png`,
       date: dates[slug],
       iconColors: colors[slug].palette
     },

--- a/script/resize.js
+++ b/script/resize.js
@@ -25,6 +25,7 @@ function resize (file, size) {
 const resizes = icons.map(icon => resize(icon, 32))
   .concat(icons.map(icon => resize(icon, 64)))
   .concat(icons.map(icon => resize(icon, 128)))
+  .concat(icons.map(icon => resize(icon, 256)))
 
 Promise.all(resizes)
   .then(function (results) {

--- a/test/machine-data.js
+++ b/test/machine-data.js
@@ -27,8 +27,14 @@ describe('machine-generated app data (exported by the module)', () => {
     expect(apps.every(app => app.slug.length > 0)).to.equal(true)
   })
 
-  it('sets a .png `icon` property on every app', () => {
-    expect(apps.every(app => !!app.icon.match(/\.png$/))).to.equal(true)
+  it('sets a multi-size icon properties on every app', () => {
+    expect(apps.every(app => {
+      return app.icon.endsWith('.png') &&
+      app.icon32.endsWith('-icon-32.png') &&
+      app.icon64.endsWith('-icon-64.png') &&
+      app.icon128.endsWith('-icon-128.png') &&
+      app.icon256.endsWith('-icon-256.png')
+    })).to.equal(true)
   })
 
   it('sets a (git-based) YYYY-MM-DD `date` property on every app', () => {


### PR DESCRIPTION
This is a followup to #591 and https://github.com/electron/electronjs.org/pull/999 so we can show bigger icons in the sidebar.