### PR TITLE
Update Signal Messenger repository URL

### DIFF
--- a/apps/signal/signal.yml
+++ b/apps/signal/signal.yml
@@ -1,7 +1,7 @@
 name: Signal
 description: 'Private Messenger'
 website: 'https://signal.org'
-repository: 'https://github.com/WhisperSystems/Signal-Desktop'
+repository: 'https://github.com/signalapp/Signal-Desktop'
 homebrewCaskName: signal
 keywords:
     - communication


### PR DESCRIPTION
We recently renamed our GitHub organization. This change updates the URL of our repository.