### PR TITLE
Updated octopi-init.yml

### DIFF
--- a/apps/octopi-init/octopi-init.yml
+++ b/apps/octopi-init/octopi-init.yml
@@ -2,7 +2,7 @@ name: octopi-init
 description: 'A Node.js & Electron application for easily configuring your freshly-imaged OctoPi microSD adapter'
 website: 'https://github.com/OutsourcedGuru/octopi-init'
 category: Utilities
-repository: 'https://github.com/OutsourcedGuru/octopi-init.git'
+repository: 'https://github.com/OutsourcedGuru/octopi-init/blob/master/electron_README.md'
 keywords:
     - octoprint
     - octopi


### PR DESCRIPTION
Unfortunately, the yaml file is a snapshot in time and doesn't reflect the latest/greatest download link(s). It was necessary to create a separate `electron_README.md` as an endpoint.
