### PR TITLE
Disable Thunder app, ref #602

### DIFF
--- a/apps/thunder/thunder.yml
+++ b/apps/thunder/thunder.yml
@@ -6,3 +6,4 @@ keywords:
 locales:
     - es-NI
 category: 'Social Networking'
+disabled: true # Thunder website is down, no info found anywhere else


### PR DESCRIPTION
As mentioned in https://github.com/electron/apps/issues/602:

> The app [Thunder](https://electronjs.org/apps/thunder) seems to be outdated as it’s unreachable and I couldn’t find further info anywhere.
> 
> According to whois.net, the domain trollswebapp.com expired 2 days ago. I couldn’t find the icon or description anywhere else either.
> 
> cc @davidsolorzano20 who added it with https://github.com/electron/apps/pull/214