### PR TITLE
chore: increase color test timeout

### DIFF
--- a/test/colors-spec.js
+++ b/test/colors-spec.js
@@ -20,8 +20,6 @@ describe('colors', function () {
   let testDir
   const slugsAndIconPaths = []
 
-  this.timeout(5000)
-
   before(async function () {
    // create a couple of test icons in a tmpdir
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'colors-spec'))
@@ -66,7 +64,7 @@ describe('colors', function () {
           .and
           .property('path')
             .equals(path.basename(entry.iconPath))
-  })
+  }).timeout(5000)
 
   it('should add an entry when a new app is added', async () => {
     const oldColors = await Colors.getColors(slugsAndIconPaths.slice(0, 1), {}, testDir)

--- a/test/colors-spec.js
+++ b/test/colors-spec.js
@@ -20,6 +20,8 @@ describe('colors', function () {
   let testDir
   const slugsAndIconPaths = []
 
+  this.timeout(5000)
+
   before(async function () {
    // create a couple of test icons in a tmpdir
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'colors-spec'))


### PR DESCRIPTION
The test is timing out without any further error information. Example: https://github.com/electron/apps/issues/798

Increase the timeout to test the theory that it's just a slow box running the tests, rather than some other kind of problem.

<!--
Thanks for submitting your app!

Please be sure you're following the guidelines at 
https://github.com/electron/electron-apps/blob/master/contributing.md

To make it easier for folks to review your submission, please 
include screenshots and URLs in the body of the pull request.
-->