### PR TITLE
fix: Travis CI link in readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "wizard": "node wizard.js",
     "release": "script/release.sh"
   },
-  "repository": "https://github.com/electron/electron-apps",
+  "repository": "https://github.com/electron/apps",
   "keywords": [
     "electron",
     "apps",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# electron-apps [![Build Status](https://travis-ci.org/electron/electron-apps.svg?branch=master)](https://travis-ci.org/electron/electron-apps)
+# electron-apps [![Build Status](https://travis-ci.org/electron/apps.svg?branch=master)](https://travis-ci.org/electron/apps)
 
 A collection of apps built on Electron. [electron.atom.io/apps](http://electron.atom.io/apps).
 


### PR DESCRIPTION
Fixed the link in Travis CI. Was previously pointing at a non-existent page (probably because of repository renaming).

Also: update repository URL in package.json