### PR TITLE
fix: update asset links for `Ao` & `Tusk` apps

### DIFF
--- a/apps/ao/ao.yml
+++ b/apps/ao/ao.yml
@@ -1,7 +1,7 @@
 name: Ao
 description: 'Elegant Microsoft To-Do desktop app'
-website: 'https://klauscfhq.github.io/ao'
-repository: 'https://github.com/klauscfhq/ao'
+website: 'https://klaussinani.github.io/ao'
+repository: 'https://github.com/klaussinani/ao'
 keywords:
     - to-do
     - productivity
@@ -10,4 +10,4 @@ license: MIT
 category: 'Productivity'
 screenshots:
     -
-        imageUrl: 'https://cdn.rawgit.com/klauscfhq/ao/125924ed/media/dark-theme.png'
+        imageUrl: 'https://raw.githubusercontent.com/klaussinani/ao/master/media/dark-theme.png'

--- a/apps/tusk/tusk.yml
+++ b/apps/tusk/tusk.yml
@@ -1,7 +1,7 @@
 name: Tusk
 description: 'Refined Evernote desktop app'
-website: 'https://klauscfhq.github.io/tusk'
-repository: 'https://github.com/klauscfhq/tusk'
+website: 'https://klaussinani.github.io/tusk'
+repository: 'https://github.com/klaussinani/tusk'
 snapcraftName: tusk
 keywords:
     - note
@@ -12,14 +12,14 @@ license: MIT
 category: 'Productivity'
 screenshots:
     -
-        imageUrl: 'https://cdn.rawgit.com/klauscfhq/tusk/33f2eae5/media/dark-theme.png'
+        imageUrl: 'https://raw.githubusercontent.com/klaussinani/tusk/master/media/dark-theme.png'
         caption: 'Dark theme'
-        imageLink: 'https://klauscfhq.github.io/tusk'
+        imageLink: 'https://klaussinani.github.io/tusk'
     -
-        imageUrl: 'https://cdn.rawgit.com/klauscfhq/tusk/33f2eae5/media/vibrant-theme.png'
+        imageUrl: 'https://raw.githubusercontent.com/klaussinani/tusk/master/media/vibrant-theme.png'
         caption: 'Vibrant theme'
-        imageLink: 'https://klauscfhq.github.io/tusk'
+        imageLink: 'https://klaussinani.github.io/tusk'
     -
-        imageUrl: 'https://cdn.rawgit.com/klauscfhq/tusk/33f2eae5/media/black-theme.png'
+        imageUrl: 'https://raw.githubusercontent.com/klaussinani/tusk/master/media/black-theme.png'
         caption: 'Black theme'
-        imageLink: 'https://klauscfhq.github.io/tusk'
+        imageLink: 'https://klaussinani.github.io/tusk'


### PR DESCRIPTION
A minor fix, that updates the links pointing to media assets, repositories and websites related to the [**Ao**](https://github.com/klaussinani/ao) and [**Tusk**](https://github.com/klaussinani/tusk) apps. Please feel free to suggest any changes : )