### PR TITLE
feat: Add and correct bunqDesktop information

### DIFF
--- a/apps/bunqdesktop/bunqdesktop.yml
+++ b/apps/bunqdesktop/bunqdesktop.yml
@@ -1,6 +1,8 @@
-name: BunqDesktop
-description: 'A desktop implementation for the bunq API.'
-website: 'https://bunqdesktop.com'
-repository: 'https://github.com/BunqCommunity/BunqDesktop'
-category: 'Finance'
-homebrewCaskName: bunq
+name: bunqDesktop
+description: 'The unofficial, free and open source desktop application for the bunq API.'
+website: 'https://bunqdesk.top'
+repository: 'https://github.com/bunqCommunity/bunqDesktop'
+category: Finance
+licence: MIT
+homebrewCaskName: 'bunqcommunity-bunq'
+snapcraftName: bunqdesktop


### PR DESCRIPTION
Some of the information is outdated and I added some missing fields like the license and snapcraft name

Related issue bunqCommunity/bunqDesktop#443