### PR TITLE
fix: version should be 1.5779.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-apps",
-  "version": "1.5778.0",
+  "version": "1.5779.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-apps",
-  "version": "1.5778.0",
+  "version": "1.5779.0",
   "description": "A collection of apps built on Electron",
   "main": "index.json",
   "scripts": {


### PR DESCRIPTION
This tag got created: https://github.com/electron/apps/releases/tag/v1.5779.0
but the version in `package.json` wasn't correspondingly updated. This PR does that.

/cc @BinaryMuse 