### PR TITLE
Update insomnia license

### DIFF
--- a/apps/insomnia/insomnia.yml
+++ b/apps/insomnia/insomnia.yml
@@ -8,7 +8,7 @@ keywords:
     - API
     - developer tools
     - GraphQL
-license: AGPL-3.0
+license: MIT
 category: 'Developer Tools'
 homebrewCaskName: insomnia
 screenshots:


### PR DESCRIPTION
License is changed from AGPL to MIT since getinsomnia/insomnia@3db00f5.