### PR TITLE
fix: push version bump before tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,35 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "@types/node": {
       "version": "6.0.88",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
@@ -230,6 +259,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-map": {
@@ -523,14 +558,17 @@
       "dev": true
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -545,6 +583,12 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "check-for-leaks": {
       "version": "1.2.0",
@@ -749,6 +793,42 @@
       "requires": {
         "chai": "^3.0.0",
         "mumath": "^1.0.2"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
+        }
       }
     },
     "color-measure": {
@@ -1026,20 +1106,12 @@
       }
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -2059,6 +2131,12 @@
         "is-property": "^1.0.0"
       }
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-image-colors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/get-image-colors/-/get-image-colors-1.8.1.tgz",
@@ -2904,6 +2982,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3059,6 +3143,12 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -3127,6 +3217,12 @@
         "lodash._isiterateecall": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "lolex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -3393,6 +3489,27 @@
       "requires": {
         "cwise-compiler": "^1.1.2",
         "ndarray": "^1.0.13"
+      }
+    },
+    "nise": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "node-abi": {
@@ -3747,6 +3864,15 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -3755,6 +3881,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -4402,6 +4534,32 @@
         }
       }
     },
+    "sinon": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -4728,6 +4886,12 @@
         }
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4808,9 +4972,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "build:pack": "node script/pack",
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",
-    "test": "mocha --reporter min test/human-data.js test/colors-spec.js && standard --fix",
+    "test": "mocha --reporter spec test/human-data.js test/colors-spec.js && standard --fix",
     "pretest-all": "npm run build",
-    "test-all": "mocha --reporter min && standard --fix",
+    "test-all": "mocha --reporter spec && standard --fix",
     "wizard": "node wizard.js",
     "release": "script/release.sh"
   },
@@ -32,8 +32,9 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "license": "MIT",
   "devDependencies": {
+    "@octokit/rest": "^15.15.1",
     "bottleneck": "^1.16.0",
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "check-for-leaks": "^1.2.0",
     "cheerio": "^1.0.0-rc.2",
     "clean-deep": "^2.0.1",
@@ -42,7 +43,6 @@
     "dotenv-safe": "^4.0.4",
     "duration": "^0.2.0",
     "get-image-colors": "^1.8.1",
-    "@octokit/rest": "^15.15.1",
     "github-url-to-object": "^4.0.2",
     "human-interval": "^0.1.6",
     "husky": "^0.14.3",
@@ -59,6 +59,7 @@
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.6.1",
     "sharp": "^0.20.8",
+    "sinon": "^7.2.2",
     "slugg": "^1.1.0",
     "standard": "^10.0.2",
     "yamljs": "^0.2.8"

--- a/script/release.sh
+++ b/script/release.sh
@@ -15,5 +15,6 @@ git config user.name "Electron Bot"
 git add .
 git commit -am "update apps" --author "Electron Bot <electron@github.com>"
 npm version minor -m "bump minor to %s"
-git push origin master --follow-tags
+git push origin master
+git push origin master --tags
 npm publish

--- a/test/colors-spec.js
+++ b/test/colors-spec.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
+const sinon = require('sinon')
 
 const chai = require('chai')
 const Jimp = require('jimp')
@@ -15,45 +16,51 @@ const expect = chai.expect
 const Colors = require('../lib/colors.js')
 
 describe('colors', function () {
-  let infos
-  let errors
   let consoleInfo
   let consoleError
   let testDir
   const slugsAndIconPaths = []
 
+  const colors = ['white', 'black']
+
   before(async function () {
    // create a couple of test icons in a tmpdir
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'colors-spec'))
-    const colors = ['white', 'black']
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'colors-spec-'))
     for (const colorName of colors) {
       const c = parseInt(tinyColor(colorName).toHex8(), 16)
-      const image = await new Jimp(2, 2, c)
+      const image = new Jimp(2, 2, c)
       const iconPath = path.join(testDir, colorName + '.png')
-      image.write(iconPath)
+      await new Promise((resolve, reject) =>
+        image.write(iconPath, (err, buffer) =>
+          err ? reject(err) : resolve(buffer)
+        )
+      )
+      fs.chmodSync(iconPath, 511)
       slugsAndIconPaths.push({'slug': colorName, iconPath})
+    }
+  })
+
+  beforeEach(() => {
+    for (const colorName of colors) {
+      const iconPath = path.join(testDir, colorName + '.png')
+      fs.chmodSync(iconPath, 511)
     }
   })
 
   after(() => {
     // remove the temporaries that were created in before()
-    for (const entry of slugsAndIconPaths) { fs.unlinkSync(entry.iconPath) }
+    for (const entry of fs.readdirSync(testDir)) { fs.unlinkSync(path.resolve(testDir, entry)) }
     fs.rmdirSync(testDir)
   })
 
   beforeEach(() => {
-    errors = []
-    consoleError = console.error
-    console.error = (...args) => errors.push(args)
-
-    infos = []
-    consoleInfo = console.info
-    console.info = (...args) => infos.push(args)
+    consoleError = sinon.stub(console, 'error')
+    consoleInfo = sinon.stub(console, 'info')
   })
 
   afterEach(() => {
-    console.error = consoleError
-    console.infos = consoleInfo
+    consoleError.restore()
+    consoleInfo.restore()
   })
 
   it('should create entries with the expected properties', async () => {
@@ -79,7 +86,7 @@ describe('colors', function () {
     // newColors should be a superset of oldColors
     newColors.should.deep.contain(oldColors)
     oldColors.should.not.deep.contain(newColors)
-    expect(infos).to.have.lengthOf(2)
+    expect(consoleInfo.callCount).to.equal(2)
   })
 
   it('should remove an entry when an app is removed', async () => {
@@ -88,14 +95,14 @@ describe('colors', function () {
     // newColors should be a subset of oldColors
     newColors.should.not.deep.contain(oldColors)
     oldColors.should.deep.contain(newColors)
-    expect(infos).to.have.lengthOf(2)
+    expect(consoleInfo.callCount).to.equal(2)
   })
 
   it('should create reproducible output', async () => {
     const a = await Colors.getColors(slugsAndIconPaths, {}, testDir)
     const b = await Colors.getColors(slugsAndIconPaths, {}, testDir)
     a.should.deep.equal(b)
-    expect(infos).to.have.lengthOf(4)
+    expect(consoleInfo.callCount).to.equal(4)
   })
 
   it('should skip entries whose icons are unreadable', async() => {
@@ -104,7 +111,6 @@ describe('colors', function () {
     const input = [badEntry, goodEntry]
 
     // make the first icon unreadable
-    const oldMode = fs.statSync(badEntry.iconPath).mode
     fs.chmodSync(badEntry.iconPath, 0)
 
     const colors = await Colors.getColors(input, {}, testDir)
@@ -113,15 +119,10 @@ describe('colors', function () {
       .and
       .not.have.keys(badEntry.slug)
 
-    expect(errors)
-      .to.have.lengthOf(1)
-      .and
-      .to.satisfy(errors => JSON.stringify(errors).includes(badEntry.iconPath))
+    expect(consoleError.callCount).to.equal(1)
+    expect(consoleError.firstCall.args[0]).to.include(badEntry.iconPath)
 
-    expect(infos).to.have.lengthOf(1)
-
-    // cleanup
-    fs.chmodSync(badEntry.iconPath, oldMode)
+    expect(consoleInfo.callCount).to.equal(1)
   })
 
   it('should skip entries whose icons are unparsable', async() => {
@@ -137,15 +138,10 @@ describe('colors', function () {
       .and
       .not.have.keys(badEntry.slug)
 
-    expect(errors)
-      .to.have.lengthOf(1)
-      .and
-      .to.satisfy(errors => JSON.stringify(errors).includes(badEntry.iconPath))
+    expect(consoleError.callCount).to.equal(1)
+    expect(consoleError.firstCall.args[0]).to.include(badEntry.iconPath)
 
-    expect(infos).to.have.lengthOf(2)
-
-    // cleanup
-    fs.unlinkSync(badEntry.iconPath)
+    expect(consoleInfo.callCount).to.equal(2)
   })
 
   it('should update revHashes when icon files change', async() => {
@@ -169,6 +165,6 @@ describe('colors', function () {
       .property('revHash')
       .should.not.equal(oldColors[changedEntry.slug].source.revHash)
 
-    expect(infos).to.have.lengthOf(3)
+    expect(consoleInfo.callCount).to.equal(3)
   })
 })


### PR DESCRIPTION
Closes #802 
Fixes #804 

If we push code changes before tags we will either

* Fail to push code and therefore no tags will be pushed so no conflict
* Succeed in pushing code and regardless of whether the tag is pushed there will be no conflict as it will bump correctly the next time

The tests failed because of #804 so I decided to fix that in this PR