### PR TITLE
chore: add playbook

### DIFF
--- a/playbook/closed-source-needs-evidence.md
+++ b/playbook/closed-source-needs-evidence.md
@@ -1,0 +1,1 @@
+Looks like this app is closed source. As per the [submission guidelines](https://github.com/electron/apps/blob/master/contributing.md#submission-guidelines), could you provide some evidence that this is an Electron app? [Previous PRs](https://github.com/electron/apps/pulls?utf8=%E2%9C%93&q=is%3Apr+evidence) are a good source for what other apps have used as evidence. Thanks!

--- a/playbook/possible-trademark-issue.md
+++ b/playbook/possible-trademark-issue.md
@@ -1,0 +1,7 @@
+As per https://github.com/electron/apps/blob/master/contributing.md#company-logos-and-names --
+
+If {{COMPANY}} has given you permission to use that name, please provide that information in the PR so that the app's name can be used as-is. Otherwise,
+
+> Please do not directly use another company's name or product without permission. It's generally better to refer to it in a dependent clause; for example, after "compatible with", "on", or "for."
+>
+> For example, while we would not accept a third-party app named "GitHub Notifications", we would consider "Yourname Notifications for GitHub".


### PR DESCRIPTION
Adds canned responses for two evergreen issues:
1. Closed-source apps which don't provide evidence that they use Electron
2. Possible trademark issues