### PR TITLE
build: add automatic semantic title changer

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,3 +11,14 @@ action "Update data and release" {
     "NPM_AUTH_TOKEN",
   ]
 }
+
+workflow "Update Pull Request title with Semantic" {
+  resolves = ["Update PRs"]
+  on = "pull_request"
+}
+
+action "Update PRs" {
+  uses = "actions/npm@master"
+  args = "run automatic-semantic"
+  secrets = ["GH_TOKEN"]
+}

--- a/automation/make-title-semantic.ts
+++ b/automation/make-title-semantic.ts
@@ -1,0 +1,129 @@
+import * as Octokit from '@octokit/rest'
+
+const github = new Octokit({
+  auth: process.env.GH_TOKEN
+})
+
+const OWNER = 'HashimotoYT'
+const REPO = 'apps'
+const BOTNAME = 'semantic-pull-requests[bot]'
+
+const SEMANTIC_TITLE = (semantic: string = 'feat:', original: string) => `${semantic} ${original}`
+
+// @ts-ignore
+const POSSIBLE_FEAT = [
+  'Adds',
+  'Added',
+  'Add',
+  'Adding',
+  'Created'
+]
+
+const POSSIBLE_FEAT_ARRAY = new Set<{ title: string, number: number }>()
+
+// @ts-ignore
+const POSSIBLE_FIX = [
+  'Updated',
+  'Update',
+  'update'
+]
+
+const POSSIBLE_FIX_ARRAY = new Set<{ title: string, number: number }>()
+
+
+async function getPRs() {
+  const getPRs = await github.pulls.list({
+    owner: OWNER,
+    repo: REPO,
+    per_page: 100
+  })
+  return getPRs.data
+}
+
+async function getCommits(prNumber: number): Promise<{ status: string, commit?: string }> {
+  const getCommits = await github.pulls.listCommits({
+    owner: OWNER,
+    repo: REPO,
+    pull_number: prNumber,
+    per_page: 50
+  })
+
+  const commit = getCommits.data.reverse()[0].sha
+
+  const getChecks = await github.repos.listStatusesForRef({
+    owner: OWNER,
+    repo: REPO,
+    ref: commit
+  })
+
+  const checks = getChecks.data.filter(x => x.creator.login === BOTNAME)
+
+  for (const check of checks) {
+    if (check.state === 'pending' as 'pending') {
+      return {
+        status: check.state,
+        commit
+      }
+    }
+  }
+
+  return {
+    status: 'success',
+  }
+}
+
+async function getPRTitle (prNumber: number) {
+  const prTitle = await github.pulls.get({
+    owner: OWNER,
+    repo: REPO,
+    pull_number: prNumber
+  })
+
+  return prTitle.data.title
+}
+
+async function updatePRTitle (prNumber: number, title: string) {
+  const prTitle = await github.pulls.update({
+    owner: OWNER,
+    repo: REPO,
+    pull_number: prNumber,
+    title
+  })
+
+  return prTitle
+}
+
+async function main() {
+  const pullRequests = await getPRs()
+  for (const pr of pullRequests) {
+    const semanticStatus = await getCommits(pr.number)
+    if (semanticStatus.status === 'success') continue
+    const prTitle = await getPRTitle(pr.number)
+
+    if (prTitle.includes('feat: ')) continue
+    if (prTitle.includes('fix: ')) continue
+    if (prTitle.includes('Add')) POSSIBLE_FEAT_ARRAY.add({ title: prTitle, number: pr.number })
+    if (prTitle.includes('Updated')) POSSIBLE_FIX_ARRAY.add({ title: prTitle, number: pr.number })
+    if (POSSIBLE_FEAT_ARRAY.size === 0) continue
+    if (POSSIBLE_FIX_ARRAY.size === 0) continue
+  }
+
+
+  for (const feats of POSSIBLE_FEAT_ARRAY) {
+    const updatedTitle = SEMANTIC_TITLE('feat: ', feats.title)
+    await updatePRTitle(feats.number, updatedTitle)
+    console.log(`Successfully updated PR: ${feats.number} to semantic title`)
+  }
+
+
+  for (const fixs of POSSIBLE_FIX_ARRAY) {
+    const updatedTitle = SEMANTIC_TITLE('fix: ', fixs.title)
+    await updatePRTitle(fixs.number, updatedTitle)
+    console.log(`Successfully updated PR: ${fixs.number} to semantic title.`)
+  }
+}
+
+main().catch((err: Error) => {
+  console.log('Something goes wrong: ', err)
+  process.exit(1)
+})

--- a/automation/make-title-semantic.ts
+++ b/automation/make-title-semantic.ts
@@ -10,24 +10,10 @@ const BOTNAME = 'semantic-pull-requests[bot]'
 
 const SEMANTIC_TITLE = (semantic: string = 'feat:', original: string) => `${semantic} ${original}`
 
-// @ts-ignore
-const POSSIBLE_FEAT = [
-  'Adds',
-  'Added',
-  'Add',
-  'Adding',
-  'Created'
-]
-
+const POSSIBLE_FEAT = new RegExp('adds|added|add|adding|created|create', 'gmi')
 const POSSIBLE_FEAT_ARRAY = new Set<{ title: string, number: number }>()
 
-// @ts-ignore
-const POSSIBLE_FIX = [
-  'Updated',
-  'Update',
-  'update'
-]
-
+const POSSIBLE_FIX = new RegExp('updated|updates|update', 'gmi')
 const POSSIBLE_FIX_ARRAY = new Set<{ title: string, number: number }>()
 
 
@@ -102,8 +88,8 @@ async function main() {
 
     if (prTitle.includes('feat: ')) continue
     if (prTitle.includes('fix: ')) continue
-    if (prTitle.includes('Add')) POSSIBLE_FEAT_ARRAY.add({ title: prTitle, number: pr.number })
-    if (prTitle.includes('Updated')) POSSIBLE_FIX_ARRAY.add({ title: prTitle, number: pr.number })
+    if (prTitle.match(POSSIBLE_FEAT)) POSSIBLE_FEAT_ARRAY.add({ title: prTitle, number: pr.number })
+    if (prTitle.match(POSSIBLE_FIX)) POSSIBLE_FIX_ARRAY.add({ title: prTitle, number: pr.number })
     if (POSSIBLE_FEAT_ARRAY.size === 0) continue
     if (POSSIBLE_FIX_ARRAY.size === 0) continue
   }
@@ -112,14 +98,14 @@ async function main() {
   for (const feats of POSSIBLE_FEAT_ARRAY) {
     const updatedTitle = SEMANTIC_TITLE('feat: ', feats.title)
     await updatePRTitle(feats.number, updatedTitle)
-    console.log(`Successfully updated PR: ${feats.number} to semantic title`)
+    console.log(`Successfully updated PR: ${feats.number} to Feature Semantic Title`)
   }
 
 
   for (const fixs of POSSIBLE_FIX_ARRAY) {
     const updatedTitle = SEMANTIC_TITLE('fix: ', fixs.title)
     await updatePRTitle(fixs.number, updatedTitle)
-    console.log(`Successfully updated PR: ${fixs.number} to semantic title.`)
+    console.log(`Successfully updated PR: ${fixs.number} to Fixes Semantic Title.`)
   }
 }
 

--- a/automation/make-title-semantic.ts
+++ b/automation/make-title-semantic.ts
@@ -1,22 +1,25 @@
 import * as Octokit from '@octokit/rest'
 
-const github = new Octokit({
-  auth: process.env.GH_TOKEN
-})
-
+// Constants
 const OWNER = 'electron'
 const REPO = 'apps'
 const BOTNAME = 'semantic-pull-requests[bot]'
 
 const SEMANTIC_TITLE = (semantic: string = 'feat:', original: string) => `${semantic}${original}`
 
-const POSSIBLE_FEAT = new RegExp('adds|added|add|adding|created|create', 'gmi')
+const POSSIBLE_FEAT = new RegExp('adds|added|add|adding|created|create|new', 'gmi')
 const POSSIBLE_FEAT_ARRAY = new Set<{ title: string, number: number }>()
 
-const POSSIBLE_FIX = new RegExp('updated|updates|update', 'gmi')
+const POSSIBLE_FIX = new RegExp('updated|updates|update|delete|disable', 'gmi')
 const POSSIBLE_FIX_ARRAY = new Set<{ title: string, number: number }>()
 
+const github = new Octokit({
+  auth: process.env.GH_TOKEN
+})
 
+/**
+ * Get the latest 100 opened PRs.
+ */
 async function getPRs() {
   const getPRs = await github.pulls.list({
     owner: OWNER,
@@ -26,6 +29,13 @@ async function getPRs() {
   return getPRs.data
 }
 
+/**
+ * Get commits for specified pull request.
+ * Another part check sepcified commit for passing semantic check.
+ *
+ * @param prNumber The number of pull request. Takes automatically in the main
+ *                 function.
+ */
 async function getCommits(prNumber: number): Promise<{ status: string, commit?: string }> {
   const getCommits = await github.pulls.listCommits({
     owner: OWNER,
@@ -58,6 +68,12 @@ async function getCommits(prNumber: number): Promise<{ status: string, commit?: 
   }
 }
 
+/**
+ * Gets the title of specified pull request.
+ *
+ * @param prNumber The number of pull request. Takes automatically in the main
+ *                 function.
+ */
 async function getPRTitle (prNumber: number) {
   const prTitle = await github.pulls.get({
     owner: OWNER,
@@ -68,6 +84,13 @@ async function getPRTitle (prNumber: number) {
   return prTitle.data.title
 }
 
+/**
+ * Updates title of specified commit.
+ *
+ * @param prNumber The number of pull request. Takes automatically in the main
+ *                 function.
+ * @param title The tilte for whats this changes.
+ */
 async function updatePRTitle (prNumber: number, title: string) {
   const prTitle = await github.pulls.update({
     owner: OWNER,
@@ -79,7 +102,21 @@ async function updatePRTitle (prNumber: number, title: string) {
   return prTitle
 }
 
-async function createPossibleArray(pullRequests: Array<Octokit.PullsListResponseItem>) {
+/**
+ * Creates a possible Set of features or fixes titles. If the title contains the `feat: ` or `fix: `
+ * this skips, this not skips all others semantic possible commits. So if PR contains semantic
+ * title like `refactor: ` or `build: ` this anyways changes to `feat: ` or `fix: ` if this
+ * contains the possible words (for possible matches @see `POSSIBLE_FIX` and @see `POSSIBLE_FEAT`
+ * constants). If pull requests do not contain matches words, this exists with
+ * [neutral exit code](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses)
+ * (for now this good).
+ *
+ * @param pullRequests Array of pull request returned from getPRs() function. See `main` for
+ *                     more info.
+ */
+async function createPossibleArray(pullRequests: Array<Octokit.PullsListResponseItem>): Promise<void | boolean> {
+  console.log('Creating a possible semantic array of words')
+
   for (const pr of pullRequests) {
     const semanticStatus = await getCommits(pr.number)
     if (semanticStatus.status === 'success') continue
@@ -87,23 +124,37 @@ async function createPossibleArray(pullRequests: Array<Octokit.PullsListResponse
 
     if (prTitle.includes('feat: ')) continue
     if (prTitle.includes('fix: ')) continue
-    if (prTitle.match(POSSIBLE_FEAT)) POSSIBLE_FEAT_ARRAY.add({ title: prTitle, number: pr.number })
-    if (prTitle.match(POSSIBLE_FIX)) POSSIBLE_FIX_ARRAY.add({ title: prTitle, number: pr.number })
-    if (POSSIBLE_FEAT_ARRAY.size === 0) continue
-    if (POSSIBLE_FIX_ARRAY.size === 0) continue
+    if (prTitle.match(POSSIBLE_FEAT)) {
+      console.log(`Adding ${pr.number} to feature semantic array.`)
+      POSSIBLE_FEAT_ARRAY.add({ title: prTitle, number: pr.number })
+    }
+    if (prTitle.match(POSSIBLE_FIX)) {
+      console.log(`Adding ${pr.number} to fixes semantic array.`)
+      POSSIBLE_FIX_ARRAY.add({ title: prTitle, number: pr.number })
+    }
   }
+
+  if (POSSIBLE_FEAT_ARRAY.size === 0 && POSSIBLE_FIX_ARRAY.size === 0) return false
 }
 
+/**
+ * Updates the Pull Request with Feature Semantic Title.
+ */
 async function updateWithFeature() {
   for (const feats of POSSIBLE_FEAT_ARRAY) {
+    console.log(`Starting updating ${feats.number} to semantic title... (Feature Update)`)
     const updatedTitle = SEMANTIC_TITLE('feat: ', feats.title)
     await updatePRTitle(feats.number, updatedTitle)
     console.log(`Successfully updated PR: ${feats.number} to Feature Semantic Title`)
   }
 }
 
+/**
+ * Updates the Pull Request with Feature Semantic Title.
+ */
 async function updateWithFix() {
   for (const fixs of POSSIBLE_FIX_ARRAY) {
+    console.log(`Starting updating ${fixs.number} to semantic title... (Fixes Update)`)
     const updatedTitle = SEMANTIC_TITLE('fix: ', fixs.title)
     await updatePRTitle(fixs.number, updatedTitle)
     console.log(`Successfully updated PR: ${fixs.number} to Fixes Semantic Title.`)
@@ -111,8 +162,20 @@ async function updateWithFix() {
 }
 
 async function main() {
+  console.log('Getting the list of Pull Requests')
   const pullRequests = await getPRs()
-  await createPossibleArray(pullRequests)
+  if (pullRequests.length === 0) {
+    console.log('Not found opened pull requests, wow 😊')
+    process.exit(78)
+  }
+
+  const possibleArray = await createPossibleArray(pullRequests)
+
+  if (possibleArray === false) {
+    console.log('Looks like all PRs have semantic title, all fine.')
+    process.exit(78)
+  }
+
   await updateWithFeature()
   await updateWithFix()
 }

--- a/automation/make-title-semantic.ts
+++ b/automation/make-title-semantic.ts
@@ -4,7 +4,7 @@ const github = new Octokit({
   auth: process.env.GH_TOKEN
 })
 
-const OWNER = 'HashimotoYT'
+const OWNER = 'electron'
 const REPO = 'apps'
 const BOTNAME = 'semantic-pull-requests[bot]'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,42 +14,68 @@
         "regenerator-runtime": "^0.11.1"
       }
     },
-    "@octokit/rest": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.15.1.tgz",
-      "integrity": "sha512-TnuzjE880qbknEFAVqEr3VeOcE0yXo0kJEW+EK8TASpzMbykKCydei6WUmDSV3bq7aI+llkMrBYes1kIjpU7fA==",
+    "@octokit/endpoint": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.4.tgz",
+      "integrity": "sha512-DypS8gbbcc9rlOCDW0wV9a+B18+ylduj6PpxeE+qa3IK1h5b0eW4CKj5pxxXWOZUYhEKwgOnh3+Q+Y/hx/bOPw==",
       "dev": true,
       "requires": {
-        "before-after-hook": "^1.1.0",
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^2.1.0",
+        "url-template": "^2.0.8"
+      }
+    },
+    "@octokit/request": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.0.tgz",
+      "integrity": "sha512-RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^5.1.0",
+        "@octokit/request-error": "^1.0.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.1.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.2.tgz",
+      "integrity": "sha512-T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==",
+      "dev": true,
+      "requires": {
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.27.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.27.3.tgz",
+      "integrity": "sha512-WWH/SHF4kus6FG+EAfX7/JYH70EjgFYa4AAd2Lf1hgmgzodhrsoxpXPSZliZ5BdJruZPMP7ZYaPoTrYCCKYzmQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^4.0.1",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
-        "debug": "^3.1.0",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.0",
-        "lodash": "^4.17.4",
-        "node-fetch": "^2.1.1",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         }
       }
@@ -110,15 +136,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
-      }
-    },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -230,6 +247,12 @@
           }
         }
       }
+    },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.9",
@@ -343,6 +366,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -388,9 +417,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
       "dev": true
     },
     "bl": {
@@ -528,6 +557,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -1117,6 +1152,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
@@ -1166,6 +1207,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.0.0.tgz",
+      "integrity": "sha512-lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw==",
       "dev": true
     },
     "detect-libc": {
@@ -1385,21 +1432,6 @@
             "es5-ext": "^0.10.9"
           }
         }
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "es6-set": {
@@ -1815,6 +1847,42 @@
         "through": "~2.3.1"
       }
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -2165,6 +2233,27 @@
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "get-svg-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-svg-colors/-/get-svg-colors-1.4.0.tgz",
@@ -2395,27 +2484,6 @@
         }
       }
     },
-    "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
-      "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2425,33 +2493,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
       }
     },
     "human-interval": {
@@ -2731,6 +2772,23 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "dev": true,
+      "requires": {
+        "isobject": "^4.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -2772,6 +2830,12 @@
       "requires": {
         "tryit": "^1.0.1"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-svg": {
       "version": "1.1.1",
@@ -2879,11 +2943,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
       "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
-      "dev": true
-    },
-    "jpgjs": {
-      "version": "github:makr28/jpgjs#c83f107ad725b476a3441d20680a02590d8752cc",
-      "from": "jpgjs@github:makr28/jpgjs#c83f107ad725b476a3441d20680a02590d8752cc",
       "dev": true
     },
     "js-tokens": {
@@ -3180,6 +3239,12 @@
         "lodash.keys": "^3.0.0"
       }
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
@@ -3216,9 +3281,9 @@
       }
     },
     "macos-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
       "dev": true
     },
     "make-color-accessible": {
@@ -3229,6 +3294,12 @@
       "requires": {
         "color2": "^1.0.8"
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
     },
     "map-stream": {
       "version": "0.1.0",
@@ -3472,6 +3543,12 @@
         "ndarray": "^1.0.13"
       }
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "nise": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
@@ -3517,9 +3594,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
     "noop-logger": {
@@ -3562,6 +3639,15 @@
         "read-pkg": "^2.0.0",
         "shell-quote": "^1.6.1",
         "string.prototype.padend": "^3.0.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -3630,6 +3716,12 @@
         "is-extendable": "^0.1.1"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
     "omggif": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.8.tgz",
@@ -3672,13 +3764,13 @@
       "dev": true
     },
     "os-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
       "dev": true,
       "requires": {
-        "macos-release": "^1.0.0",
-        "win-release": "^1.0.0"
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-shim": {
@@ -3691,6 +3783,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -3837,6 +3935,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -4553,6 +4657,22 @@
       "integrity": "sha1-51KvIkGvPycURjxd4iXOpHYIdAo=",
       "dev": true
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
@@ -4719,6 +4839,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-indent": {
@@ -4928,6 +5054,27 @@
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
+    "ts-node": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
+      "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4964,6 +5111,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "dev": true
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -4971,12 +5124,12 @@
       "dev": true
     },
     "universal-user-agent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
-      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
       "dev": true,
       "requires": {
-        "os-name": "^2.0.1"
+        "os-name": "^3.0.0"
       }
     },
     "url-template": {
@@ -5000,8 +5153,15 @@
       "integrity": "sha512-9fl1Md7tUTsgjhWCLOra+nalQnDxWme+h0OB7WQsUBZbhrxEmzL6/suCPxI4ujrFAvv6KSu7B/74HhxfydVpfw==",
       "dev": true,
       "requires": {
-        "jpgjs": "github:makr28/jpgjs#c83f107ad725b476a3441d20680a02590d8752cc",
+        "jpgjs": "github:makr28/jpgjs",
         "pako": "^1.0.5"
+      },
+      "dependencies": {
+        "jpgjs": {
+          "version": "github:makr28/jpgjs#c83f107ad725b476a3441d20680a02590d8752cc",
+          "from": "github:makr28/jpgjs",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {
@@ -5071,13 +5231,13 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
       "dev": true,
       "requires": {
-        "semver": "^5.0.1"
+        "execa": "^1.0.0"
       }
     },
     "wordwrap": {
@@ -5156,6 +5316,12 @@
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
       }
+    },
+    "yn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "license": "MIT",
   "devDependencies": {
-    "@octokit/rest": "^15.15.1",
+    "@octokit/rest": "^16.27.3",
     "bottleneck": "^1.16.0",
     "chai": "^4.2.0",
     "check-for-leaks": "^1.2.0",
@@ -62,7 +62,9 @@
     "sinon": "^7.2.2",
     "slugg": "^1.1.0",
     "standard": "^10.0.2",
-    "yamljs": "^0.2.8"
+    "yamljs": "^0.2.8",
+    "ts-node": "^8.2.0",
+    "typescript": "^3.5.1"
   },
   "engines": {
     "node": "8"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pretest-all": "npm run build",
     "test-all": "mocha --reporter min && standard --fix",
     "wizard": "node wizard.js",
-    "release": "script/release.sh"
+    "release": "script/release.sh",
+    "automatic-semantic": "ts-node ./automation/make-title-semantic.ts"
   },
   "repository": "https://github.com/electron/apps",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "lib": [
+      "esnext"
+    ],
+    "strict": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true
+  }
+}


### PR DESCRIPTION
This PR adds automation script for changing standard title to semantic title for the pass all checks.

### Why?

> me: Good question. 😐

Mostly because when a user opens PR here not pass how minimum 1 check. It's one check it's semantic pull title, what's set user into a strange position, where last don't sure what's should do to pass to next level. (I think this description of the problem is true). This simplifies this by running its script when pr opened (or not 😂), also makes review process very small better, because the reviewer doesn't need manually update title. Robots make this automatically.

### But really, why?

I'm playing with GitHub APIs to making something strange and good, for robots and people, if it's not the very priority improvement, we can close this.

### And yep, examples 😊

See this pr list: https://github.com/HashimotoYT/apps/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc