### PR TITLE
fix: Update Move More app screenshots

### DIFF
--- a/apps/move-more/move-more.yml
+++ b/apps/move-more/move-more.yml
@@ -15,18 +15,18 @@ keywords:
     - active
 screenshots:
   -
-    imageUrl: 'https://deskrelief.co.uk/img/feature/feature-1.jpg'
+    imageUrl: 'https://deskrelief.co.uk/screenshots/1.jpg'
     caption: 'Move More!'
     imageLink: 'https://www.deskrelief.co.uk'
   -
-    imageUrl: 'https://deskrelief.co.uk/img/feature/feature-2.jpg'
+    imageUrl: 'https://deskrelief.co.uk/screenshots/2.jpg'
     caption: 'Move More!'
     imageLink: 'https://www.deskrelief.co.uk'
   -
-    imageUrl: 'https://deskrelief.co.uk/img/feature/feature-3.jpg'
+    imageUrl: 'https://deskrelief.co.uk/screenshots/3.jpg'
     caption: 'Move More!'
     imageLink: 'https://www.deskrelief.co.uk'
   -
-    imageUrl: 'https://deskrelief.co.uk/img/feature/feature-4.jpg'
+    imageUrl: 'https://deskrelief.co.uk/screenshots/4.jpg'
     caption: 'Move More!'
     imageLink: 'https://www.deskrelief.co.uk'


### PR DESCRIPTION
Changed the screenshots to ones that fit the width and height ratio used on https://electronjs.org/apps/move-more

old: https://deskrelief.co.uk/img/feature/feature-2.jpg (app only screenshot)
new: https://deskrelief.co.uk/screenshots/2.jpg (full screen 16:9 ratio)