### PR TITLE
fix: allow any node version higher than 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "yamljs": "^0.2.8"
   },
   "engines": {
-    "node": "8"
+    "node": ">=8"
   },
   "dependencies": {
     "json-stable-stringify": "^1.0.1",


### PR DESCRIPTION
Yeah, node 10/12 should totally be allowed to consume this module 👍 