### PR TITLE
chore: disable Brave Browser

### DIFF
--- a/apps/brave-browser/brave-browser.yml
+++ b/apps/brave-browser/brave-browser.yml
@@ -4,3 +4,4 @@ website: 'https://brave.com/'
 keywords:
     - browser
 category: Productivity
+disabled: true # Brave Browser started using Chromium directly in 2018 (https://brave.com/brave-upgrades/)


### PR DESCRIPTION
Not sure if this is allowed because this is not my app, but Brave Browser stopped using their Electron fork (Muon) last year. They now use Chromium directly.

This PR adds the `disabled` flag on their app.

See: https://brave.com/brave-upgrades/