### PR TITLE
feat: use a shallow fetch when pulling code for CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 1
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Because the apps repo has a lot of binary files and churn, it takes about three minutes to get a snapshot ready to run CI on. ([example CI run](https://github.com/electron/apps/pull/1191/checks?check_run_id=230321354))

This PR limits the fetch depth in hopes of speeding that up. ([documentation](https://github.com/actions/checkout/blob/master/action.yml), [code example](https://github.com/marketplace/actions/markdown-link-check))

Looks like we might've been hitting this overhead before the Actions migration, too?