### PR TITLE
chore: add playbook for closing stale prs

### DIFF
--- a/playbook/closing-no-info-changes.md
+++ b/playbook/closing-no-info-changes.md
@@ -1,0 +1,1 @@
+Thanks for your interesting of adding your application into the repository, unfortunately, you don't provide required information/changes in a required time, and we need to close this PR. If you still want in adding your application please open new PR with the required information/changes.


### PR DESCRIPTION
I'm starting marking PR what's required changes/info by `blocked/no-info` label and give 7 days for an answer. If the author doesn't provide information in that period I'm closing PR as stale. This gives some small visibility for me where changes requested where not.

This PR adds gracefully closing message what are describing why this be closed.

/cc @ckerr 