### PR TITLE
chore: Change fnew-desktop.yml

### DIFF
--- a/apps/fnew-desktop/fnew-desktop.yml
+++ b/apps/fnew-desktop/fnew-desktop.yml
@@ -1,6 +1,6 @@
 name: 'FNew Desktop'
 description: 'Natively use FNew from your device, without needing to wait for your browser to start.'
-website: 'https://marnix0810.github.io/FNew/desktop-apps/'
+website: 'https://fnew-social.net/desktop-apps/'
 category: 'Social Networking'
-repository: 'https://github.com/marnix0810/FNew-Desktop-Windows'
+repository: 'https://github.com/0810-Software/FNew-Desktop-Windows'
 license: MIT


### PR DESCRIPTION
FNew has moved to org:0810-software and has gotten its own domain: https://fnew-social.net

<!--
Thanks for submitting your app!

Please be sure you're following the guidelines at 
https://github.com/electron/electron-apps/blob/master/contributing.md

To make it easier for folks to review your submission, please 
include screenshots and URLs in the body of the pull request.
-->