### PR TITLE
Improve `schedule.yml` workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,17 +1,21 @@
-on:
-  schedule:
-  - cron: 0 */12 * * *
-
 name: Update and release
 
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+
 jobs:
-  updateDataAndRelease:
-    name: Update data and release
+  update-and-release:
+    name: Update and release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Update data and release
-      run: npm run release
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Update and release
+        run: npm run release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This PR improves the `schedule.yml` GitHub Actions workflow:

- Introduces an `actions/setup-node` step before the execution of the `release` script, which defines the Node version that should be used. Might help reproducing #1278.
- Uses a specific version of the `checkout` action (instead of using the `master` branch)
- Adds quotes around the `cron` value (recommended in the [GitHub Actions docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions) because `*` is a special character in YAML)