### PR TITLE
feat: Updated website URL for ueli

### DIFF
--- a/apps/ueli/ueli.yml
+++ b/apps/ueli/ueli.yml
@@ -1,6 +1,6 @@
 name: ueli
 description: 'This is a keystroke launcher for Windows and macOS.'
-website: 'https://github.com/oliverschwendener/ueli'
+website: 'https://ueli.app'
 repository: 'https://github.com/oliverschwendener/ueli'
 keywords:
     - keystroke


### PR DESCRIPTION
This PR updates the URL to [ueli](https://github.com/oliverschwendener/ueli)'s [website](https://ueli.app).