### PR TITLE
fix: Twinkle Tray screenshot

### DIFF
--- a/apps/twinkle-tray/twinkle-tray.yml
+++ b/apps/twinkle-tray/twinkle-tray.yml
@@ -10,3 +10,5 @@ keywords:
     - ddc-ic
     - windows
     - brightness-control
+screenshots:
+    - {imageUrl: 'https://raw.githubusercontent.com/xanderfrangos/twinkle-tray/gh-pages/assets/img/twinkle-tray-screenshot.jpg'}


### PR DESCRIPTION
Screenshot was not included in the original yml.