### PR TITLE
feat: use js-yaml instead of yamljs

### DIFF
--- a/lib/raw-app-list.js
+++ b/lib/raw-app-list.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const yaml = require('yamljs')
+const yaml = require('js-yaml')
 
 module.exports = function getSlugs () {
   return fs.readdirSync(path.join(__dirname, '../apps'))
@@ -15,7 +15,7 @@ module.exports = function getSlugs () {
           slug: slug,
           iconPath: path.join(__dirname, `../apps/${slug}/${slug}-icon.png`)
         },
-        yaml.load(yamlFile)
+        yaml.safeLoad(fs.readFileSync(yamlFile))
       )
       return app
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,7 +252,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -797,7 +797,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1078,7 +1078,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1458,7 +1458,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -6400,7 +6400,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7521,7 +7521,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "sinon": "^7.2.2",
     "slugg": "^1.1.0",
     "standard": "^10.0.2",
-    "yamljs": "^0.2.8"
+    "yamljs": "^0.2.8",
+    "js-yaml": "^3.13.1"
   },
   "engines": {
     "node": ">=8"

--- a/script/pack.js
+++ b/script/pack.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const yaml = require('yamljs')
+const yaml = require('js-yaml')
 const dates = require('../meta/dates.json')
 const colors = require('../meta/colors.json')
 const releases = require('../meta/releases.json')
@@ -16,7 +16,7 @@ fs.readdirSync(path.join(__dirname, '../apps'))
   const yamlFile = path.join(__dirname, `../apps/${slug}/${slug}.yml`)
   const app = Object.assign(
     {slug: slug},
-    yaml.load(yamlFile),
+    yaml.safeLoad(fs.readFileSync(yamlFile)),
     {
       icon: `${slug}-icon.png`,
       icon32: `${slug}-icon-32.png`,

--- a/test/human-data.js
+++ b/test/human-data.js
@@ -5,7 +5,7 @@ const it = mocha.it
 const fs = require('fs')
 const path = require('path')
 const expect = require('chai').expect
-const yaml = require('yamljs')
+const yaml = require('js-yaml')
 const isUrl = require('is-url')
 const { URL } = require('url')
 const cleanDeep = require('clean-deep')
@@ -41,7 +41,7 @@ describe('human-submitted app data', () => {
       })
 
       describe(`${yamlFile}`, () => {
-        const app = yaml.load(yamlPath)
+        const app = yaml.safeLoad(fs.readFileSync(yamlPath))
 
         it('has a name', () => {
           expect(app.name.length).to.be.above(0)


### PR DESCRIPTION
This PR updates the `yaml` parser from `yamljs` to `js-yaml` what's work more flexible and has more understandable error reporting. `yamljs` still used in places where need some more work to migrate.