### PR TITLE
docs: discontinue notice

### DIFF
--- a/apps/voltra/voltra.yml
+++ b/apps/voltra/voltra.yml
@@ -1,5 +1,6 @@
-name: Voltra (discontinued)
-description: 'Voltra was  A modern, hi-def, distraction-free music player'
+name: Voltra
+description: 'A modern, hi-def, distraction-free music player'
+disabled: true # Homepage closed and development stopped around April 2019: https://twitter.com/voltraco/status/1123153090251771905
 website: 'https://voltra.co'
 keywords:
   - music

--- a/apps/voltra/voltra.yml
+++ b/apps/voltra/voltra.yml
@@ -1,5 +1,5 @@
-name: Voltra
-description: 'A modern, hi-def, distraction-free music player'
+name: Voltra (discontinued)
+description: 'Voltra was  A modern, hi-def, distraction-free music player'
 website: 'https://voltra.co'
 keywords:
   - music


### PR DESCRIPTION
Voltra is sadly not available anymore: https://twitter.com/voltraco/status/1123153090251771905
The homepage is offline along with the blog post, that explained, that voltra stopped development...
