### PR TITLE
feat: Disable TeamSQL

### DIFF
--- a/apps/teamsql/teamsql.yml
+++ b/apps/teamsql/teamsql.yml
@@ -3,6 +3,7 @@ description: 'Multi-platform SQL Client - Extensible, Simple and Effortless'
 website: 'https://teamsql.io'
 category: 'Developer Tools'
 repository: 'https://github.com/TeamSQL/desktop-app'
+disabled: true # TeamSQL became DataRow, which is now an AWS company. TeamSQL not available as a standalone app anymore.
 keywords:
   - database
   - sql


### PR DESCRIPTION
See the comment on the disable flag - unfortunately this doesn't seem to be available anymore.

The TeamSQL website redirects to [DataRow](https://datarow.com/) (they rebranded) where they explain the move to AWS, the TeamSQL app isn't available anymore.
 
<!--
Thanks for submitting your app!

Please be sure you're following the guidelines at 
https://github.com/electron/electron-apps/blob/master/contributing.md

To make it easier for folks to review your submission, please 
include screenshots and URLs in the body of the pull request.
-->