### PR TITLE
fix: Remove broken or deprecated apps

### DIFF
--- a/apps/checksum-validator/checksum-validator.yml
+++ b/apps/checksum-validator/checksum-validator.yml
@@ -16,3 +16,5 @@ screenshots:
 locales:
   - de
   - en
+disabled: true
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the electron version is older than 3.x ( "electron": "^2.0.10" )'

--- a/apps/hain/hain.yml
+++ b/apps/hain/hain.yml
@@ -7,3 +7,5 @@ category: Utilities
 repository: 'https://github.com/appetizermonster/hain'
 screenshots:
   - imageUrl: 'https://raw.githubusercontent.com/hainproject/hain/develop/docs/images/demo.gif'
+disabled: true
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the electron version is older than 3.x ( "electron": "^2.0.0" )'

--- a/apps/odio/odio.yml
+++ b/apps/odio/odio.yml
@@ -23,3 +23,5 @@ screenshots:
     imageLink: 'https://www.odio.io'
 
 license: MIT
+disabled: true
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the app website link is no longer works ( https://www.strimio.com/ )'

--- a/apps/odio/odio.yml
+++ b/apps/odio/odio.yml
@@ -24,4 +24,4 @@ screenshots:
 
 license: MIT
 disabled: true
-disabledComment: 'disabled in Sat, 24 Oct 2020, because the app website link is no longer works ( https://www.strimio.com/ )'
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the app website link is no longer works ( https://www.odio.io )'

--- a/apps/punk/punk.yml
+++ b/apps/punk/punk.yml
@@ -11,3 +11,5 @@ license: MIT
 screenshots:
   - imageUrl: 'https://cloud.githubusercontent.com/assets/2640934/12659057/fc11ad1c-c60c-11e5-841b-8d34e729b8e4.png'
     caption: 'Main Punk window'
+disabled: true 
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the electron version is older than 3.x ( "electron": "1.6.14" )'

--- a/apps/sandman/sandman.yml
+++ b/apps/sandman/sandman.yml
@@ -14,3 +14,5 @@ license: MIT
 category: Productivity
 screenshots:
   - imageUrl: 'https://github.com/alexanderepstein/Sandman/raw/master/assets/Usage.gif'
+disabled: true
+disabledComment: 'disabled in Sat, 24 Oct 2020, because the electron version is older than 3.x ( "electron": "^1.8.8" )'


### PR DESCRIPTION
#### ⚠️ Issue Reference #1548 
>  many apps are now broken or no longer working, and thus should be removed from our directories
---
#### What did i do?
I just found 5 apps that are using the old versions of electron, or their website link is no longer working,
so i disabled them

Please check my pull request and if you have any feedback please let me know 😄 !

Thanks.