### PR TITLE
fix: disable broken app and add safeguards

### DIFF
--- a/apps/snailfm/snailfm.yml
+++ b/apps/snailfm/snailfm.yml
@@ -7,3 +7,4 @@ keywords:
   - music
   - NCS
   - simple
+disabled: true # broken icon

--- a/lib/raw-app-list.js
+++ b/lib/raw-app-list.js
@@ -11,15 +11,20 @@ module.exports = function getSlugs() {
         .isDirectory()
     })
     .sort()
-    .map((slug) => {
+    .reduce((slugs, slug) => {
       const yamlFile = path.join(__dirname, `../apps/${slug}/${slug}.yml`)
-      const app = Object.assign(
-        {
+      const meta = yaml.load(fs.readFileSync(yamlFile))
+
+      if (meta.disabled) {
+        return slugs
+      } else {
+        const app = {
           slug: slug,
           iconPath: path.join(__dirname, `../apps/${slug}/${slug}-icon.png`),
-        },
-        yaml.load(fs.readFileSync(yamlFile))
-      )
-      return app
-    })
+          ...meta
+        }
+        return [...slugs, app]
+      }
+
+    }, [])
 }

--- a/script/pack.js
+++ b/script/pack.js
@@ -16,9 +16,15 @@ fs.readdirSync(path.join(__dirname, '../apps'))
   })
   .forEach((slug) => {
     const yamlFile = path.join(__dirname, `../apps/${slug}/${slug}.yml`)
+    const meta = yaml.load(fs.readFileSync(yamlFile))
+
+    if (meta.disabled) {
+      return;
+    }
+
     const app = Object.assign(
       { slug: slug },
-      yaml.load(fs.readFileSync(yamlFile)),
+      meta,
       {
         icon: `${slug}-icon.png`,
         icon32: `${slug}-icon-32.png`,


### PR DESCRIPTION
Fixes #1856

I found out that the SnailFM app was the culprit here due to an error processing the PNG file. I've disabled it and prevented all disabled apps from being processed in the build scripts.

cc @snaildos 
