### PR TITLE
chore: disable Booker app

### DIFF
--- a/apps/booker/booker.yml
+++ b/apps/booker/booker.yml
@@ -8,3 +8,5 @@ keywords:
   - html
   - pdf
 category: Productivity
+disabled: true
+disabledComment: 'Wed Jun 26 2019 Work on Booker was discontinued'


### PR DESCRIPTION
Work on Booker was discontinued. So it has to be disabled.