### PR TITLE
fix: cors errors on images from github repos

### DIFF
--- a/script/readmes.js
+++ b/script/readmes.js
@@ -106,10 +106,10 @@ function cleanReadme(readme, defaultBranch, app) {
       `${app.slug}: updating ${$relativeImages.length} relative image URLs`
     )
     $relativeImages.each((i, img) => {
-      $(img).attr(
-        'src',
-        `${app.repository}/raw/${defaultBranch}/${$(img).attr('src')}`
-      )
+      $(img).attr({
+        'src': `${app.repository.replace('github.com', 'raw.githubusercontent.com')}/${defaultBranch}/${$(img).attr('src')}`,
+        crossorigin: ''
+      })
     })
   }
 


### PR DESCRIPTION
## Attempt at fixing cors errors

Images from GitHub repositories are blocked because of the server's CORS headers:

<img width="793" alt="Capture d’écran 2022-04-09 à 23 41 54" src="https://user-images.githubusercontent.com/199648/162592443-45e38b0b-a4c2-4d1a-b6af-1d29331a95d3.png">

<img width="689" alt="Capture d’écran 2022-04-09 à 23 43 13" src="https://user-images.githubusercontent.com/199648/162592469-5467f632-1fbc-4348-9387-2bcad9d32928.png">

This PR should fix these errors.

See #1989
