### PR TITLE
chore: display-dj.yml: Fix typo

### DIFF
--- a/apps/display-dj/display-dj.yml
+++ b/apps/display-dj/display-dj.yml
@@ -1,4 +1,4 @@
-name: sqlui-native
+name: display-dj
 description:
   'Cross platform desktop application that supports brightness adjustment for
   integrated laptop monitor as well as external monitors and dark mode toggle


### PR DESCRIPTION
Fix typo: The app's name was wrong!