### PR TITLE
fix: update and release pipeline

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -5,8 +5,6 @@ set -o errexit    # always exit on error
 set -o pipefail   # honor exit codes when piping
 set -o nounset    # fail on unset variables
 
-git clone "https://electron-bot:$GH_TOKEN@github.com/electron/apps" app
-cd app
 npm ci
 
 npm run test-all


### PR DESCRIPTION
### Description

Right now the repo was cloned by [actions/checkout@v3](https://github.com/electron/apps/blob/dee0bd804fc7ad76e634ab2b630a48c5c9bfbf83/.github/workflows/schedule.yml#L12) as well as inside the `release.sh` script which was leading to [](url)
![Screenshot 2022-09-24 at 9 11 38 PM](https://user-images.githubusercontent.com/16779465/192106745-ddbfc27a-8bab-4511-9c27-628f4a994a8e.png)

Removed the redundant cloning of the repo inside the `release.sh` script
