### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -4,6 +4,9 @@ on:
 
 name: Update and release
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   updateDataAndRelease:
     name: Update data and release

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -7,8 +7,13 @@ on:
       - edited
       - synchronize
 
+permissions: {}
 jobs:
   main:
+    permissions:
+      pull-requests: read # to analyze PRs (amannn/action-semantic-pull-request)
+      statuses: write # to mark status of analyzed PR (amannn/action-semantic-pull-request)
+
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.