### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @electron/wg-ecosystem
-* @toinane
+* @electron/wg-ecosystem @toinane


### PR DESCRIPTION
Current version ignores `@electron/wg-ecosystem`.