### PR TITLE
ci: remove unused GitHub app config file

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,2 +1,0 @@
-# Always validate the PR title, and ignore the commits
-titleOnly: true


### PR DESCRIPTION
No longer used since switching to `.github/workflows/semantic.yml`.