### PR TITLE
fix: Add repo link to Freeter

### DIFF
--- a/apps/freeter/freeter.yml
+++ b/apps/freeter/freeter.yml
@@ -1,6 +1,7 @@
 name: Freeter
 description: 'The smartest way to work on your projects'
 website: 'https://freeter.io'
+repository: 'https://github.com/FreeterApp/Freeter'
 keywords:
   - productivity
   - organizer


### PR DESCRIPTION
This PR does not add a new application. It adds a github repo link to an existing one.