### PR TITLE
ci: update branch for `test` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 permissions: {}
 


### PR DESCRIPTION
Looks like we haven't been running tests since the default branch was renamed at some point.