### PR TITLE
Trackabi: Remove invalid repo

### DIFF
--- a/apps/trackabi/trackabi.yml
+++ b/apps/trackabi/trackabi.yml
@@ -5,7 +5,6 @@ description:
   applications used. Trackabi is an excellent choice for freelancers, small &
   medium-sized enterprises.'
 website: 'https://trackabi.com'
-repository: 'https://github.com/Trackabi/desktop-time-tracking'
 youtube_video_url: 'https://www.youtube.com/watch?v=kQQDDb0qzuE'
 keywords:
   - Time tracking application


### PR DESCRIPTION
https://github.com/Trackabi/desktop-time-tracking is disabled by GitHub staff. Repo has nothing.