### PR TITLE
docs: remove CoC reference from contributing md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -2,11 +2,6 @@
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
-This project adheres to the Contributor Covenant
-[code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report
-unacceptable behavior to electron@github.com.
-
 The following is a set of guidelines for contributing to `electron-apps`. These
 are just guidelines, not rules. Use your best judgment and feel free to propose
 changes to this document in a pull request.


### PR DESCRIPTION
Given that [the CoC document is up to date in the ](https://github.com/electron/.github/pull/53)[`.github`](https://github.com/electron/.github/pull/53)[ repository](https://github.com/electron/.github/pull/53), this reference should be removed so that the `.github` CoC is the only one visible and mentioned in this repository.

### Description

Removed Code of Conduction mention from contributing.md
